### PR TITLE
Changed the way project-, library- and core-files are extracted.

### DIFF
--- a/Symfony/src/Codebender/CompilerBundle/Controller/DefaultController.php
+++ b/Symfony/src/Codebender/CompilerBundle/Controller/DefaultController.php
@@ -59,7 +59,7 @@ class DefaultController extends Controller
             //Get the compiler service
 			$compiler = $this->get('compiler_handler');
 
-			$reply = $compiler->main($request, $params, true);
+			$reply = $compiler->main($request, $params);
 
 			return new Response(json_encode($reply));
 		}

--- a/Symfony/src/Codebender/CompilerBundle/Handler/CompilerHandler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/CompilerHandler.php
@@ -39,7 +39,7 @@ class CompilerHandler
 	\param string $request The body of the POST request.
 	\return A message to be JSON-encoded and sent back to the requestor.
 	 */
-	function main($request, $compiler_config, $initCall)
+	function main($request, $compiler_config)
 	{
 		error_reporting(E_ALL & ~E_STRICT);
 
@@ -52,35 +52,42 @@ class CompilerHandler
 		// Step 0: Reject the request if the input data is not valid.
 		//TODO: Replace $tmp variable name
 		$tmp = $this->requestValid($request);
-		if($tmp["success"] == false)
+		if($tmp["success"] === false)
 			return $tmp;
-		
-		/*
-			$initCall variable is a flag which is set to true if this instance of the compiler is called
-			by the DefaultController. Then the logging parameters need to be set properly if the $request 
-			demands so. When the compiler is called by the UtilityHandler to compile core or library files,
-			$initCall is set to false
-		*/
-		if($initCall)	
-			$this->setLoggingParams(json_encode($request), $compiler_config);
+
+        //Set logging to true if requested, and create the directory where logfiles are stored.
+        //TODO: Replace $tmp variable name
+		$tmp = $this->setLoggingParams($request, $compiler_config);
+        if($tmp["success"] === false)
+            return $tmp;
 		
 		$this->set_variables($request, $format, $libraries, $version, $mcu, $f_cpu, $core, $variant, $vid, $pid);
 
 		$target_arch = "-mmcu=$mcu -DARDUINO=$version -DF_CPU=$f_cpu -DUSB_VID=$vid -DUSB_PID=$pid";
 		$clang_target_arch = "-D".MCUHandler::$MCU[$mcu]." -DARDUINO=$version -DF_CPU=$f_cpu";
 
-		// Step 1: Extract the files included in the request.
-		$tmp = $this->extractFiles($request, $dir, $files);
+		// Step 1(part 1): Extract the project files included in the request.
+        $files = array();
+		$tmp = $this->extractFiles($request["files"], $compiler_dir, $files["sketch_files"], "files");
 		if ($tmp["success"] == false)
 			return $tmp;
 
+        // Step 1(part 2): Extract the library files included in the request.
+        $files["libs"] = array();
+        foreach($libraries as $library => $library_files){
+
+            $tmp = $this->extractFiles($library_files, $compiler_dir, $files["libs"][$library], "libraries/$library");
+            if ($tmp["success"] == false)
+                return $tmp;
+        }
+
 		// Step 2: Preprocess Arduino source files.
-		$tmp = $this->preprocessIno($files, $ARDUINO_CORES_DIR, $version, $core);
+		$tmp = $this->preprocessIno($files["sketch_files"]);
 		if ($tmp["success"] == false)
 			return $tmp;
 
 		// Step 3: Preprocess Header includes.
-		$tmp = $this->preprocessHeaders($files, $libraries, $include_directories, $dir, $ARDUINO_CORES_DIR, $version, $core, $variant);
+		$tmp = $this->preprocessHeaders($libraries, $include_directories, $compiler_dir, $ARDUINO_CORES_DIR, $version, $core, $variant);
 		if ($tmp["success"] == false)
 			return $tmp;
 
@@ -88,20 +95,25 @@ class CompilerHandler
 		//Use the include paths for the AVR headers that are bundled with each Arduino SDK version
 		$core_includes = " -I$ARDUINO_CORES_DIR/v$version/hardware/tools/avr/lib/gcc/avr/4.3.2/include -I$ARDUINO_CORES_DIR/v$version/hardware/tools/avr/lib/gcc/avr/4.3.2/include-fixed -I$ARDUINO_CORES_DIR/v$version/hardware/tools/avr/avr/include ";
 
-		$tmp = $this->doCompile($compiler_config, $files, $dir, $CC, $CFLAGS, $CPP, $CPPFLAGS, $AS, $ASFLAGS, $CLANG, $CLANG_FLAGS, $core_includes, $target_arch, $clang_target_arch, $include_directories, $format);
-		if ($tmp["success"] == false)
-			return $tmp;
+        //handleCompile sets any include directories needed and calls the doCompile function, which does the actual compilation
+        $ret = $this->handleCompile("$compiler_dir/files", $files["sketch_files"], $compiler_config, $CC, $CFLAGS, $CPP, $CPPFLAGS, $AS, $ASFLAGS, $CLANG, $CLANG_FLAGS, $core_includes, $target_arch, $clang_target_arch, $include_directories["main"], $format);
+
+        if (!$ret["success"])
+			return $ret;
 
 		if ($format == "syntax")
 			return array(
 				"success" => true,
 				"time" => microtime(true) - $start_time);
 
+        //Keep all object files urls needed for linking.
+        $objects_to_link = $files["sketch_files"]["o"];
+
 		//TODO: return objects if more than one file??
 		if ($format == "object")
 		{
-			$content = base64_encode(file_get_contents($files["o"][0].".o"));
-			if (count($files["o"]) != 1 || !$content)
+			$content = base64_encode(file_get_contents($files["sketch_files"]["o"][0].".o"));
+			if (count($files["sketch_files"]["o"]) != 1 || !$content)
 				return array(
 					"success" => false,
 					"step" => -1, //TODO: Fix this step?
@@ -113,8 +125,8 @@ class CompilerHandler
 					"output" => $content);
 		}
 
-		
-		//Link all core object files to a core.a library
+        // Step 5: Create objects for core files (if core file does not already exist)
+		//Link all core object files to a core.a library.
 		$core_dir = "$ARDUINO_CORES_DIR/v$version/hardware/arduino/cores/$core";
         //TODO: Figure out why Symfony needs "@" to suppress mkdir wanring
         if(!file_exists($this->object_directory))
@@ -124,54 +136,56 @@ class CompilerHandler
                     "step" => 5,
                     "message" => "Could not create object files directory.");
             }
-		$core_name = $this->object_directory ."/". pathinfo(str_replace("/", "__", $core_dir."_"), PATHINFO_FILENAME)."_______"."${mcu}_${f_cpu}_${core}_${variant}".(($variant == "leonardo") ? "_${vid}_${pid}" : "")."_______"."core.a";
-		
-		if(!file_exists($core_name)){
-		
-		// Step 5: Create objects for core files.
-		//TODO: make it compatible with non-default hardware (variants & cores)
-		$core_objects = $this->create_objects($compiler_config, $core_dir, false, true, array(), $version, $mcu, $f_cpu, $core, $variant, $vid, $pid);
-		//TODO: Upgrade this
-		if (array_key_exists("success", $core_objects))
-			return $core_objects;
-		/*
-		the line bellow had to be commented so that the core object files will not be linked again to the 
-		output file in step 7
-		*/
-		//$files["o"] = array_merge($files["o"], $core_objects);
-		
-		
-			foreach($core_objects as $core_obj){
-					exec("$AR $ARFLAGS $core_name $core_obj.o", $output);
-					//Remove object file, since its contents are now linked to the core.a file
-					if(file_exists("$core_obj.o"))
-                        unlink("$core_obj.o");
-					if($compiler_config['logging']){
-						file_put_contents($compiler_config['logFileName'], "$AR $ARFLAGS $core_name $core_obj.o"."\n", FILE_APPEND);
-					}
-			}
-		}
-		
-		
-		// Step 6: Create objects for libraries.
-		foreach ($files["dir"] as $directory)
-		{
-			$library_objects = $this->create_objects($compiler_config, $directory, true, false, $libraries, $version, $mcu, $f_cpu, $core, $variant, $vid, $pid);
-			//TODO: Upgrade this
-			if (array_key_exists("success", $library_objects))
-				return $library_objects;
-			$files["o"] = array_merge($files["o"], $library_objects);
+		//Generate full pathname of the cores library and then check if the library exists.
+        $core_library = $this->object_directory ."/". pathinfo(str_replace("/", "__", $core_dir."_"), PATHINFO_FILENAME)."_______"."${mcu}_${f_cpu}_${core}_${variant}".(($variant == "leonardo") ? "_${vid}_${pid}" : "")."_______"."core.a";
+
+		if(!file_exists($core_library)){
+
+            //makeCoresTmp scans the core files directory and return list including the urls of the files included there.
+            $tmp = $this->makeCoresTmp($core_dir, $compiler_dir, $files);
+
+            if(!$tmp["success"])
+                return $tmp;
+
+            $ret = $this->handleCompile("$compiler_dir/core", $files["core"], $compiler_config, $CC, $CFLAGS, $CPP, $CPPFLAGS, $AS, $ASFLAGS, $CLANG, $CLANG_FLAGS, $core_includes, $target_arch, $clang_target_arch, $include_directories["core"], "object");
+
+            if(!$ret["success"])
+                return $ret;
+
+            foreach($files["core"]["o"] as $core_object){
+                //Link object file to library.
+                exec("$AR $ARFLAGS $core_library $core_object.o", $output);
+
+                if($compiler_config['logging'])
+                    file_put_contents($compiler_config['logFileName'], "$AR $ARFLAGS $core_library $core_object.o"."\n", FILE_APPEND);
+            }
 		}
 
-		// Step 7: Link all object files and create executable.
+
+        // Step 6: Create objects for libraries.
+		foreach ($files["libs"] as $library_name => $library_files){
+
+            //The elements of the "build" array are needed to build the unique name of every library object file.
+            $lib_object_naming_params = $request["build"];
+            $lib_object_naming_params["library"] = $library_name;
+
+            $ret = $this->handleCompile("$compiler_dir/libraries/$library_name", $files["libs"][$library_name], $compiler_config, $CC, $CFLAGS, $CPP, $CPPFLAGS, $AS, $ASFLAGS, $CLANG, $CLANG_FLAGS, $core_includes, $target_arch, $clang_target_arch, $include_directories["main"], $format, true, $lib_object_naming_params);
+
+            if(!$ret["success"])
+                return $ret;
+
+            $objects_to_link = array_merge($objects_to_link, $files["libs"][$library_name]["o"]);
+            }
+
+        // Step 7: Link all object files and create executable.
 		$object_files = "";
-		foreach ($files["o"] as $object)
+		foreach ($objects_to_link as $object)
 			$object_files .= " ".escapeshellarg("$object.o");
 
 		//Link core.a and every other object file to a .elf binary file
-		exec("$LD $LDFLAGS $target_arch $object_files $core_name -o $dir/$OUTPUT.elf $LDFLAGS_TAIL 2>&1", $output, $ret_link);
+		exec("$LD $LDFLAGS $target_arch $object_files $core_library -o $compiler_dir/files/$OUTPUT.elf $LDFLAGS_TAIL 2>&1", $output, $ret_link);
 		if($compiler_config['logging']){
-						file_put_contents($compiler_config['logFileName'], "$LD $LDFLAGS $target_arch $object_files $core_name -o $dir/$OUTPUT.elf $LDFLAGS_TAIL\n", FILE_APPEND);
+						file_put_contents($compiler_config['logFileName'], "$LD $LDFLAGS $target_arch $object_files $core_library -o $compiler_dir/files/$OUTPUT.elf $LDFLAGS_TAIL\n", FILE_APPEND);
 					}
 		if ($ret_link)
 			return array(
@@ -181,7 +195,7 @@ class CompilerHandler
 
 		// Step 8: Convert the output to the requested format and measure its
 		// size.
-		$tmp = $this->convertOutput($dir, $format, $SIZE, $SIZE_FLAGS, $OBJCOPY, $OBJCOPY_FLAGS, $OUTPUT, $start_time, $compiler_config);
+		$tmp = $this->convertOutput("$compiler_dir/files", $format, $SIZE, $SIZE_FLAGS, $OBJCOPY, $OBJCOPY_FLAGS, $OUTPUT, $start_time, $compiler_config);
 		return $tmp;
 
 	}
@@ -197,12 +211,13 @@ class CompilerHandler
 		else return array("success" => true);
 	}
 
-	private function extractFiles($request, &$dir, &$files)
+	private function extractFiles($request, &$dir, &$files, $suffix)
 	{
 		// Create a temporary directory to place all the files needed to process
 		// the compile request. This directory is created in $TMPDIR or /tmp by
 		// default and is automatically removed upon execution completion.
-		$dir = System::mktemp("-t /tmp/ -d compiler.");
+		if(!$dir)
+            $dir = System::mktemp("-t /tmp/ -d compiler.");
 
 		if (!$dir)
 			return array(
@@ -210,28 +225,16 @@ class CompilerHandler
 				"step" => 1,
 				"message" => "Failed to create temporary directory.");
 
-		$response = $this->utility->extract_files($dir, $request->files);
+        $response = $this->utility->extract_files("$dir/$suffix", $request);
+
 		if ($response["success"] === false)
 			return $response;
 		$files = $response["files"];
 
-		if (!file_exists($dir."/libraries"))
-			mkdir($dir."/libraries/", 0777, true);
-		//TODO: check if it succeeded
-		$files["libs"] = array();
-		foreach($request->libraries as $library_name => $library_files)
-		{
-			//TODO: check if it succeeded
-			if (!file_exists($dir."/libraries".$library_name))
-				mkdir($dir."/libraries/".$library_name, 0777, true);
-			$tmp = $this->utility->extract_files($dir."/libraries/".$library_name, $library_files);
-			$files["libs"][] = $tmp["files"];
-		}
-
 		return array("success" => true);
 	}
 
-	private function preprocessIno(&$files, $ARDUINO_CORES_DIR, $version, $core)
+	private function preprocessIno(&$files)
 	{
 		foreach ($files["ino"] as $file)
 		{
@@ -251,7 +254,7 @@ class CompilerHandler
 		return array("success" => true);
 	}
 
-	public function preprocessHeaders(&$files, &$libraries, &$include_directories, $dir, $ARDUINO_CORES_DIR, $version, $core, $variant)
+	public function preprocessHeaders($libraries, &$include_directories, $dir, $ARDUINO_CORES_DIR, $version, $core, $variant)
 	{
 		try
 		{
@@ -259,20 +262,12 @@ class CompilerHandler
 			// current directory is added to eliminate the difference between <>
 			// and "" in include preprocessor directives.
 			//TODO: make it compatible with non-default hardware (variants & cores)
-			$include_directories = "-I$dir -I$ARDUINO_CORES_DIR/v$version/hardware/arduino/cores/$core -I$ARDUINO_CORES_DIR/v$version/hardware/arduino/variants/$variant";
+            $include_directories = array();
+			$include_directories["core"] = " -I$ARDUINO_CORES_DIR/v$version/hardware/arduino/cores/$core -I$ARDUINO_CORES_DIR/v$version/hardware/arduino/variants/$variant";
 
-			//TODO: The code that rests on the main website looks for headers in all files, not just c, cpp and h. Might raise a security issue
-			$files["dir"] = array();
-			foreach($libraries as $library_name => $library_files)
-			{
-				$files["dir"][] = $dir."/libraries/".$library_name;
-			}
-
-			// Add the libraries' paths in the include paths in the command-line arguments
-			if (file_exists("$dir/utility"))
-				$include_directories .= " -I$dir/utility";
-			foreach ($files["dir"] as $directory)
-				$include_directories .= " -I$directory";
+            $include_directories["main"] = $include_directories["core"];
+			foreach ($libraries as $library_name => $library_files)
+				$include_directories["main"] .= " -I$dir/libraries/$library_name";
 		}
 		catch(\Exception $e)
 		{
@@ -282,7 +277,7 @@ class CompilerHandler
 		return array("success" => true);
 	}
 
-	private function doCompile($compiler_config, &$files, $dir, $CC, $CFLAGS, $CPP, $CPPFLAGS, $AS, $ASFLAGS, $CLANG, $CLANG_FLAGS, $core_includes, $target_arch, $clang_target_arch, $include_directories, $format)
+	private function doCompile($compiler_config, &$files, $dir, $CC, $CFLAGS, $CPP, $CPPFLAGS, $AS, $ASFLAGS, $CLANG, $CLANG_FLAGS, $core_includes, $target_arch, $clang_target_arch, $include_directories, $format, $caching = false, $name_params = null)
 	{
 		if ($format == "syntax")
 		{
@@ -294,51 +289,63 @@ class CompilerHandler
 		{
 			foreach ($files[$ext] as $file)
 			{
-				// From hereon, $file is shell escaped and thus should only be used in calls
-				// to exec().
-				$file = escapeshellarg($file);
+                if($caching)
+                    $object_file =$this->object_directory."/${name_params['mcu']}_${name_params['f_cpu']}_${name_params['core']}_${name_params['variant']}".(($name_params['variant'] == "leonardo") ? "_${name_params['vid']}_${name_params['pid']}" : "")."______${name_params['library']}_______".((pathinfo(pathinfo($file, PATHINFO_DIRNAME), PATHINFO_FILENAME) == "utility") ? "utility_______" : "") .pathinfo($file, PATHINFO_FILENAME);
+				else
+                    $object_file = escapeshellarg($file);
+                if(!file_exists("$object_file.o")){
+                    // From hereon, $file is shell escaped and thus should only be used in calls
+                    // to exec().
+                    $file = escapeshellarg($file);
 
-				//replace exec() calls with $this->utility->debug_exec() for debugging
-				if ($ext == "c")
-					{
-					exec("$CC $CFLAGS $core_includes $target_arch $include_directories -c -o $file.o $file.$ext 2>&1", $output, $ret_compile);
-					if($compiler_config['logging']){
-						file_put_contents($compiler_config['logFileName'],"$CC $CFLAGS $core_includes $target_arch $include_directories -c -o $file.o $file.$ext\n", FILE_APPEND);
-						}
-					}
-				elseif ($ext == "cpp")
-					{
-					exec("$CPP $CPPFLAGS $core_includes $target_arch $include_directories -c -o $file.o $file.$ext 2>&1", $output, $ret_compile);
-					if($compiler_config['logging']){
-						file_put_contents($compiler_config['logFileName'],"$CPP $CPPFLAGS $core_includes $target_arch $include_directories -c -o $file.o $file.$ext\n", FILE_APPEND);
-						}
-					}
-				elseif ($ext == "S")
-					{
-					exec("$AS $ASFLAGS $target_arch $include_directories -c -o $file.o $file.$ext 2>&1", $output, $ret_compile);
-					if($compiler_config['logging']){
-						file_put_contents($compiler_config['logFileName'],"$AS $ASFLAGS $target_arch $include_directories -c -o $file.o $file.$ext\n", FILE_APPEND);
-						}
-					}
-				if (isset($ret_compile) && $ret_compile)
-				{
-					$avr_output = implode("\n", $output);
-					unset($output);
-					exec("$CLANG $CLANG_FLAGS $core_includes $clang_target_arch $include_directories -c -o $file.o $file.$ext 2>&1", $output, $ret_compile);
-					if($compiler_config['logging']){
-						file_put_contents($compiler_config['logFileName'],"$CLANG $CLANG_FLAGS $core_includes $clang_target_arch $include_directories -c -o $file.o $file.$ext\n", FILE_APPEND);
-						}
-					$output = str_replace("$dir/", "", $output); // XXX
-					$output = $this->postproc->ansi_to_html(implode("\n", $output));
-					return array(
-						"success" => false,
-						"step" => 4,
-						"message" => $output,
-						"debug" => $avr_output);
-				}
-				unset($output);
+                    //replace exec() calls with $this->utility->debug_exec() for debugging
+                    if ($ext == "c")
+                        {
+                        exec("$CC $CFLAGS $core_includes $target_arch $include_directories -c -o $object_file.o $file.$ext 2>&1", $output, $ret_compile);
+                        if($compiler_config['logging']){
+                            file_put_contents($compiler_config['logFileName'],"$CC $CFLAGS $core_includes $target_arch $include_directories -c -o $object_file.o $file.$ext\n", FILE_APPEND);
+                            }
+                        }
+                    elseif ($ext == "cpp")
+                        {
+                        exec("$CPP $CPPFLAGS $core_includes $target_arch -MMD $include_directories -c -o $object_file.o $file.$ext 2>&1", $output, $ret_compile);
+                        if($compiler_config['logging']){
+                            file_put_contents($compiler_config['logFileName'],"$CPP $CPPFLAGS $core_includes $target_arch -MMD $include_directories -c -o $object_file.o $file.$ext\n", FILE_APPEND);
+                            }
+                        }
+                    elseif ($ext == "S")
+                        {
+                        exec("$AS $ASFLAGS $target_arch $include_directories -c -o $object_file.o $file.$ext 2>&1", $output, $ret_compile);
+                        if($compiler_config['logging']){
+                            file_put_contents($compiler_config['logFileName'],"$AS $ASFLAGS $target_arch $include_directories -c -o $object_file.o $file.$ext\n", FILE_APPEND);
+                            }
+                        }
+                    if (isset($ret_compile) && $ret_compile)
+                    {
+                        $avr_output = implode("\n", $output);
+                        unset($output);
+                        exec("$CLANG $CLANG_FLAGS $core_includes $clang_target_arch $include_directories -c -o $object_file.o $file.$ext 2>&1", $output, $ret_compile);
+                        if($compiler_config['logging']){
+                            file_put_contents($compiler_config['logFileName'],"$CLANG $CLANG_FLAGS $core_includes $clang_target_arch $include_directories -c -o $object_file.o $file.$ext\n", FILE_APPEND);
+                            }
+                        $output = str_replace("$dir/", "", $output); // XXX
+                        $output = $this->postproc->ansi_to_html(implode("\n", $output));
+                        return array(
+                            "success" => false,
+                            "step" => 4,
+                            "message" => $output,
+                            "debug" => $avr_output);
+                    }
+                    unset($output);
+                }
 
-				$files["o"][] = array_shift($files[$ext]);
+                if(!$caching){
+				    $files["o"][] = array_shift($files[$ext]);
+                }
+                else{
+                    $files["o"][] = $object_file;
+                    array_shift($files[$ext]);
+                }
 			}
 		}
 
@@ -433,25 +440,24 @@ class CompilerHandler
 	private function set_variables($request, &$format, &$libraries, &$version, &$mcu, &$f_cpu, &$core, &$variant, &$vid, &$pid)
 	{
 		// Extract the request options for easier access.
-		$format = $request->format;
-		$libraries = $request->libraries;
-		$version = $request->version;
-		$mcu = $request->build->mcu;
-		$f_cpu = $request->build->f_cpu;
-		$core = $request->build->core;
-		$variant = $request->build->variant;
+		$format = $request["format"];
+		$libraries = $request["libraries"];
+		$version = $request["version"];
+		$mcu = $request["build"]["mcu"];
+		$f_cpu = $request["build"]["f_cpu"];
+		$core = $request["build"]["core"];
+		$variant = $request["build"]["variant"];
 
 		// Set the appropriate variables for vid and pid (Leonardo).
-		$vid = ($variant == "leonardo") ? $request->build->vid : "null";
-		$pid = ($variant == "leonardo") ? $request->build->pid : "null";
+		$vid = ($variant == "leonardo") ? $request["build"]["vid"] : "null";
+		$pid = ($variant == "leonardo") ? $request["build"]["pid"] : "null";
 	}
 	
 	private function setLoggingParams($request, &$compiler_config)
 	{
-		$temp = json_decode($request,true);
 		//Check if $request['logging'] exists and is true, then make the logfile, otherwise set
 		//$compiler_config['logdir'] to false and return to caller
-		if(array_key_exists('logging', $temp) && $temp['logging'])
+		if(array_key_exists('logging', $request) && $request['logging'])
 		{
 			/*
 			Generate a random part for the log name based on current date and time,
@@ -463,175 +469,86 @@ class CompilerHandler
 			and mix them all together
 			*/
 			
-			foreach($temp['files'] as $file){
+			foreach($request['files'] as $file){
 				if(strcmp(pathinfo($file['filename'], PATHINFO_EXTENSION), "ino") == 0){$basename = pathinfo($file['filename'], PATHINFO_FILENAME);}
 			}
 			if(!isset($basename)){$basename="logfile";}
 			
 			$compiler_config['logging'] = true;
 			$directory = $compiler_config['logdir'];
-			if(!file_exists($directory)){mkdir($directory);}
+			if(!file_exists($directory))
+                if(!@mkdir($directory))
+                    return array("success"=>false, "message"=>"Failed to create logfiles directory.");
+
 			
 			$compiler_config['logFileName'] = $directory ."/". $basename ."_". $randPart .".txt";
 			
 			file_put_contents($compiler_config['logFileName'], '');
 		}
-		elseif(!array_key_exists('logging', $temp) or !$temp['logging'])
-		{
+		elseif(!array_key_exists('logging', $request) or !$request['logging'])
 			$compiler_config['logging'] = false;
-		}
+
+        return array("success"=>true);
 	}
 
+
     /**
-    \brief Creates objects for every source file in a directory.
+    \brief Reads all core files from the respective directory and passes their contents to extractFiles function
+    which then rights them to the compiler temp directory
 
-    \param string $directory The directory where the sources are located.
-    \param bool $send_headers <b>TRUE</b> if this directory contains a library.
-    \param bool libc_headers <b>TRUE</b> when creating core object files
-    \param string $mcu <b>mcu</b> build flag.
-    \param string $f_cpu <b>f_cpu</b> build flag.
-    \param string $core <b>core</b> build flag.
-    \param string $variant <b>variant</b> build flag.
-    \param string $vid <b>vid</b> build flag (Leonardo).
-    \param string $pid <b>pid</b> build flag (Leonardo).
-    \return An array of object files or a reply message in case of error.
 
-    In case of error, the return value is an array that has a key <b>success</b>
-    and contains the response to be sent back to the user.
+    \param string $core_files_directory The directory containing the core files.
+    \param string $tmp_compiler The tmp directory where the actual compilation process takes place.
+    \return array An array containing the function results.
      */
+    private function makeCoresTmp($core_files_directory, $tmp_compiler, &$files){
 
-    function create_objects($compiler_config, $directory, $send_headers, $libc_headers, $libraries, $version, $mcu, $f_cpu, $core, $variant, $vid, $pid)
-    {
-        $request_template = array(
-            "format" => "object",
-            "version" => $version,
-            "libraries" => $libraries,
-            "build" => array(
-                "mcu" => $mcu,
-                "f_cpu" => $f_cpu,
-                "core" => $core,
-                "variant" => $variant,
-                "vid" => $vid,
-                "pid" => $pid));
+        $core = array();
+        if(false === ($scanned_files = @scandir($core_files_directory)))
+            return array( "success"=>false, "step"=>5, "message"=>"Failed to read core files." );
 
-        $object_files = array();
-        $sources = $this->utility->get_files_by_extension($directory, array("c", "cpp", "S"));
+        // Get the contents of the core files
+        foreach ($scanned_files as $core_file)
+            if(!is_dir("$core_files_directory/$core_file"))
+                $core[] = array("filename" => $core_file, "content" => file_get_contents("$core_files_directory/$core_file"));
 
-        if (file_exists("$directory/utility"))
-        {
-            $utility_sources = $this->utility->get_files_by_extension("$directory/utility", array("c", "cpp", "S"));
-            foreach ($utility_sources as &$i)
-                $i = "utility/$i";
-            unset($i);
-            $sources = array_merge($sources, $utility_sources);
+        // Check if the version of the core files includes an avr-libc directory and scan
+        if(file_exists("$core_files_directory/avr-libc")){
+            if(false === ($scanned_avr_files = @scandir("$core_files_directory/avr-libc")))
+                return array( "success"=>false, "step"=>5, "message"=>"Failed to read core files." );
+            foreach($scanned_avr_files as $avr_file)
+                if(!is_dir("$core_files_directory/avr-libc/$avr_file"))
+                    $core[] = array("filename" => "avr-libc/$avr_file", "content" => file_get_contents("$core_files_directory/avr-libc/$avr_file"));
         }
 
-        if (file_exists("$directory/avr-libc") && $libc_headers)
-        {
-            $avr_libc_sources = $this->utility->get_files_by_extension("$directory/avr-libc", array("c", "cpp", "S"));
-            foreach ($avr_libc_sources as &$i)
-                $i = "avr-libc/$i";
-            unset($i);
-            $sources = array_merge($sources, $avr_libc_sources);
-        }
 
-        foreach ($sources as $filename)
-        {
-            // If $send_headers is set the compiler is trying to make the object files
-            // for some library. In order to make the object filename unique across
-            // several libraries, the library name should be added to it. In this case,
-            // the library name is included in the $directory variable.
+        $tmp = $this->extractFiles($core, $tmp_compiler, $files["core"], "core");
+        if($tmp["success"] === false)
+            return array( "success"=>false, "step"=>5, "message"=>$tmp["message"] );
 
-            // For every source file and set of build options there is a
-            // corresponding object file. If that object is missing, a new
-            // compile request is sent to the service.
-            //TODO: Existing Library .o files will probably not be used right now (due to /tmp/compiler.random/ dir)
-            //TODO: Investigate security issue
-            if($send_headers){
-               $object_file =$this->object_directory."/".pathinfo(str_replace("/", "__", $directory."_"), PATHINFO_FILENAME)."_______"."${mcu}_${f_cpu}_${core}_${variant}".(($variant == "leonardo") ? "_${vid}_${pid}" : "")."______".pathinfo($directory, PATHINFO_BASENAME)."_______".pathinfo(str_replace("/", "__", "$filename"), PATHINFO_FILENAME);
-            }
-            else
-                $object_file = $this->object_directory."/".pathinfo(str_replace("/", "__", $directory."_"), PATHINFO_FILENAME)."_______"."${mcu}_${f_cpu}_${core}_${variant}".(($variant == "leonardo") ? "_${vid}_${pid}" : "")."_______".pathinfo(str_replace("/", "__", "$filename"), PATHINFO_FILENAME);
-            if (!file_exists("$object_file.o"))
-            {
-                // Include any header files in the request.
-                if ($send_headers && !array_key_exists("files", $request_template))
-                {
-                    $request_template["files"] = array();
-                    $header_files = $this->utility->get_files_by_extension($directory, array("h", "inc"));
-
-                    if (file_exists("$directory/utility"))
-                    {
-                        $utility_headers = $this->utility->get_files_by_extension("$directory/utility", array("h", "inc"));
-                        foreach ($utility_headers as &$i)
-                            $i = "utility/$i";
-                        unset($i);
-                        $header_files = array_merge($header_files, $utility_headers);
-                    }
-
-                    foreach ($header_files as $header_filename)
-                    {
-                        $request_template["files"][] = array(
-                            "filename" => $header_filename,
-                            "content" => file_get_contents("$directory/$header_filename"));
-                    }
-                }
-
-                //Include header files from c library ( needed for malloc and realloc )
-                if($libc_headers && !array_key_exists("files", $request_template))
-
-                    if (file_exists("$directory/avr-libc"))
-                    {
-                        $request_template["files"] = array();
-                        $header_files = array();
-
-                        $avr_libc_headers = $this->utility->get_files_by_extension("$directory/avr-libc", array("h", "inc"));
-                        foreach ($avr_libc_headers as &$i)
-                            $i = "avr-libc/$i";
-                        unset($i);
-                        $header_files = array_merge($header_files, $avr_libc_headers);
-
-                        foreach ($header_files as $header_filename)
-                        {
-                            $request_template["files"][] = array(
-                                "filename" => $header_filename,
-                                "content" => file_get_contents("$directory/$header_filename"));
-                        }
-
-                    }
+        return array('success' => true);
+    }
 
 
-                // Include the source file.
-                $request = $request_template;
-                $request["files"][] = array(
-                    "filename" => $filename,
-                    "content" => file_get_contents("$directory/$filename"));
+    private function handleCompile($compile_directory, &$files_array, $compiler_config, $CC, $CFLAGS, $CPP, $CPPFLAGS, $AS, $ASFLAGS, $CLANG, $CLANG_FLAGS, $core_includes, $target_arch, $clang_target_arch, $include_directories, $format, $caching = false, $name_params = null){
 
-                // Perform a new compile request.
-                //$compiler = new CompilerHandler();
-                $reply = $this->main(json_encode($request), $compiler_config, false);
+        //Add any include directories needed
+        $include_directories .= " -I$compile_directory ";
 
-                if ($reply["success"] == false)
-                    return array(
-                        "success" => false,
-                        "step" => 5,
-                        "message" => $reply["message"],
-                        "debug" => $request);
+        if(file_exists("$compile_directory/utility"))
+            $include_directories .= " -I$compile_directory/utility ";
 
-                //TODO: Figure out why Symfony needs "@" to suppress file_put_contents wanring
-                if(!@file_put_contents("$object_file.o", base64_decode($reply["output"]))){
-                    return array(
-                        "success" => false,
-                        "step" => 5,
-                        "message" => "Could not create one of the object files.");
-                }
-            }
+        if (file_exists("$compile_directory/avr-libc"))
+            $include_directories .= " -I$compile_directory/avr-libc ";
 
-            $object_files[] = $object_file;
-        }
 
-        // All object files created successfully.
-        return $object_files;
+        //Call doCompile, which will do the actual compilation.
+        $compile_res = $this->doCompile($compiler_config, $files_array, $compile_directory, $CC, $CFLAGS, $CPP, $CPPFLAGS, $AS, $ASFLAGS, $CLANG, $CLANG_FLAGS, $core_includes, $target_arch, $clang_target_arch, $include_directories, $format, $caching, $name_params);
+
+        if($compile_res['success'])
+            return array("success" => true);
+
+        return $compile_res;
     }
 
 }

--- a/Symfony/src/Codebender/CompilerBundle/Handler/CompilerHandler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/CompilerHandler.php
@@ -289,9 +289,11 @@ class CompilerHandler
 		{
 			foreach ($files[$ext] as $file)
 			{
-                if($caching)
-                    $object_file =$this->object_directory."/${name_params['mcu']}_${name_params['f_cpu']}_${name_params['core']}_${name_params['variant']}".(($name_params['variant'] == "leonardo") ? "_${name_params['vid']}_${name_params['pid']}" : "")."______${name_params['library']}_______".((pathinfo(pathinfo($file, PATHINFO_DIRNAME), PATHINFO_FILENAME) == "utility") ? "utility_______" : "") .pathinfo($file, PATHINFO_FILENAME);
-				else
+                if($caching){
+                    $object_filename = "$this->object_directory/${name_params['mcu']}_${name_params['f_cpu']}_${name_params['core']}_${name_params['variant']}".(($name_params['variant'] == "leonardo") ? "_${name_params['vid']}_${name_params['pid']}" : "")."______${name_params['library']}_______".((pathinfo(pathinfo($file, PATHINFO_DIRNAME), PATHINFO_FILENAME) == "utility") ? "utility_______" : "") .pathinfo($file, PATHINFO_FILENAME);
+                    $object_file = escapeshellarg($object_filename);
+                }
+                else
                     $object_file = escapeshellarg($file);
                 if(!file_exists("$object_file.o")){
                     // From hereon, $file is shell escaped and thus should only be used in calls
@@ -343,7 +345,7 @@ class CompilerHandler
 				    $files["o"][] = array_shift($files[$ext]);
                 }
                 else{
-                    $files["o"][] = $object_file;
+                    $files["o"][] = $object_filename;
                     array_shift($files[$ext]);
                 }
 			}

--- a/Symfony/src/Codebender/CompilerBundle/Handler/CompilerHandler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/CompilerHandler.php
@@ -291,14 +291,15 @@ class CompilerHandler
 			{
                 if($caching){
                     $object_filename = "$this->object_directory/${name_params['mcu']}_${name_params['f_cpu']}_${name_params['core']}_${name_params['variant']}".(($name_params['variant'] == "leonardo") ? "_${name_params['vid']}_${name_params['pid']}" : "")."______${name_params['library']}_______".((pathinfo(pathinfo($file, PATHINFO_DIRNAME), PATHINFO_FILENAME) == "utility") ? "utility_______" : "") .pathinfo($file, PATHINFO_FILENAME);
-                    $object_file = escapeshellarg($object_filename);
+                    $object_file = $object_filename;
                 }
                 else
-                    $object_file = escapeshellarg($file);
+                    $object_file = $file;
                 if(!file_exists("$object_file.o")){
                     // From hereon, $file is shell escaped and thus should only be used in calls
                     // to exec().
                     $file = escapeshellarg($file);
+                    $object_file = escapeshellarg($object_file);
 
                     //replace exec() calls with $this->utility->debug_exec() for debugging
                     if ($ext == "c")

--- a/Symfony/src/Codebender/CompilerBundle/Handler/CompilerHandler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/CompilerHandler.php
@@ -76,7 +76,7 @@ class CompilerHandler
         $files["libs"] = array();
         foreach($libraries as $library => $library_files){
 
-            $tmp = $this->extractFiles($library_files, $compiler_dir, $files["libs"][$library], "libraries/$library");
+            $tmp = $this->extractFiles($library_files, $compiler_dir, $files["libs"][$library], "libraries/$library", true);
             if ($tmp["success"] == false)
                 return $tmp;
         }
@@ -211,7 +211,7 @@ class CompilerHandler
 		else return array("success" => true);
 	}
 
-	private function extractFiles($request, &$dir, &$files, $suffix)
+	private function extractFiles($request, &$dir, &$files, $suffix, $lib_extraction = false)
 	{
 		// Create a temporary directory to place all the files needed to process
 		// the compile request. This directory is created in $TMPDIR or /tmp by
@@ -225,7 +225,7 @@ class CompilerHandler
 				"step" => 1,
 				"message" => "Failed to create temporary directory.");
 
-        $response = $this->utility->extract_files("$dir/$suffix", $request);
+        $response = $this->utility->extract_files("$dir/$suffix", $request, $lib_extraction);
 
 		if ($response["success"] === false)
 			return $response;

--- a/Symfony/src/Codebender/CompilerBundle/Handler/PreprocessingHandler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/PreprocessingHandler.php
@@ -255,7 +255,7 @@ class PreprocessingHandler
 	 */
 	function validate_input($request)
 	{
-		$request = json_decode($request);
+		$request = json_decode($request, true);
 
 		// Request must be successfully decoded.
 		if ($request === NULL)
@@ -265,27 +265,27 @@ class PreprocessingHandler
 			&& array_key_exists("version", $request)
 			&& array_key_exists("build", $request)
 			&& array_key_exists("files", $request)
-			&& is_object($request->build)
+			&& is_array($request["build"])
 			&& array_key_exists("libraries", $request)
-			&& array_key_exists("mcu", $request->build)
-			&& array_key_exists("f_cpu", $request->build)
-			&& array_key_exists("core", $request->build)
-			&& array_key_exists("variant", $request->build)
-			&& is_array($request->files))
+			&& array_key_exists("mcu", $request["build"])
+			&& array_key_exists("f_cpu", $request["build"])
+			&& array_key_exists("core", $request["build"])
+			&& array_key_exists("variant", $request["build"])
+			&& is_array($request["files"]))
 		)
 			return NULL;
 
 		// Leonardo-specific flags.
-		if ($request->build->variant == "leonardo")
-			if (!(array_key_exists("vid", $request->build)
-				&& array_key_exists("pid", $request->build))
+		if ($request["build"]["variant"] == "leonardo")
+			if (!(array_key_exists("vid", $request["build"])
+				&& array_key_exists("pid", $request["build"]))
 			)
 				return NULL;
 
 		// Values used as command-line arguments may not contain any special
 		// characters. This is a serious security risk.
 		foreach (array("version", "mcu", "f_cpu", "core", "variant", "vid", "pid") as $i)
-			if (isset($request->build->$i) && escapeshellcmd($request->build->$i) != $request->build->$i)
+			if (isset($request["build"][$i]) && escapeshellcmd($request["build"][$i]) != $request["build"][$i])
 				return NULL;
 
 		// Request is valid.

--- a/Symfony/src/Codebender/CompilerBundle/Handler/UtilityHandler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/UtilityHandler.php
@@ -48,10 +48,13 @@ class UtilityHandler
 		// Examples: foo.c bar.cpp
 		$REGEX = "/(.*)\.($EXTENSIONS)$/";
 
+        if(!file_exists($directory))
+            mkdir($directory, 0777, true);
+
 		foreach ($request_files as $file)
 		{
-			$filename = $file->filename;
-			$content = $file->content;
+			$filename = $file["filename"];
+			$content = $file["content"];
 
 			$failure_response = array(
 				"success" => false,

--- a/Symfony/src/Codebender/CompilerBundle/Handler/UtilityHandler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/UtilityHandler.php
@@ -30,7 +30,7 @@ class UtilityHandler
 	In case of error, the return value is an array that has a key <b>success</b>
 	and contains the response to be sent back to the user.
 	 */
-	function extract_files($directory, &$request_files, $lib_extraction)
+	function extract_files($directory, $request_files, $lib_extraction)
 	{
 		// File extensions used by Arduino projects. They are put in a string,
 		// separated by "|" to be used in regular expressions. They are also
@@ -51,7 +51,7 @@ class UtilityHandler
         if(!file_exists($directory))
             mkdir($directory, 0777, true);
 
-		foreach ($request_files as $key => &$file)
+		foreach ($request_files as $file)
 		{
 			$filename = $file["filename"];
 			$content = $file["content"];
@@ -71,29 +71,23 @@ class UtilityHandler
 			if (strpos($filename, DIRECTORY_SEPARATOR))
 			{
 				$new_directory = pathinfo($filename, PATHINFO_DIRNAME);
-                if ($lib_extraction === true){
-                    if ($new_directory === "utility"){
-                        if (!file_exists("$directory/$new_directory"))
-                            mkdir("$directory/$new_directory", 0777, true);
-                        // There is no reason to check whether mkdir()
-                        // succeeded, given that the call to
-                        // file_put_contents() that follows would fail
-                        // as well.
-                    }
-                    else{
-                        unset($request_files[$key]);
-                        $ignore = true;
-                    }
-                }
-                else
-                    if (!file_exists("$directory/$new_directory"))
-                        mkdir("$directory/$new_directory", 0777, true);
+
+                if (($lib_extraction === true) && ($new_directory !== "utility"))
+                    $ignore = true;
+                if (!file_exists("$directory/$new_directory"))
+                    mkdir("$directory/$new_directory", 0777, true);
+                // There is no reason to check whether mkdir()
+                // succeeded, given that the call to
+                // file_put_contents() that follows would fail
+                // as well.
+
 			}
-            if ($ignore === true)
-                continue;
 
 			if (file_put_contents("$directory/$filename", $content) === false)
 				return $failure_response;
+
+            if ($ignore)
+                continue;
 
 			if (preg_match($REGEX, $filename, $matches))
 				$files[$matches[2]][] = "$directory/$matches[1]";


### PR DESCRIPTION
From now on, every file will be extracted to the corresponding folder in
the temporary compiler directory ("files" for project files, "libraries" for library files
and "core" for core files). During compilation of library files, if a utility folder exists,
it is included to the include directories. Thus we can avoid errors due to the inability of the
compiler to access the utility files.
