### PR TITLE
Made the service globally available at /compiler

### DIFF
--- a/apache-config
+++ b/apache-config
@@ -1,12 +1,7 @@
-<VirtualHost *:80>
-	ServerAdmin root@localhost
-    DocumentRoot /opt/codebender/compiler/Symfony/web/
-    DirectoryIndex app.php
-
-	<Directory /opt/codebender/compiler/Symfony/web>
-		Options -Indexes FollowSymLinks MultiViews
-		AllowOverride All
-		Order allow,deny
-		Allow from all
-	</Directory>
-</VirtualHost>
+AliasMatch ^/compiler/?(.*) /opt/codebender/compiler/Symfony/web/$1
+<Directory /opt/codebender/compiler/Symfony/web>
+        Options -Indexes FollowSymLinks MultiViews
+        AllowOverride All
+        Order allow,deny
+        Allow from all
+</Directory>


### PR DESCRIPTION
Changed Apache config to make /compiler accessible as a global routing and not a separate virtual host.

This allows the compiler service to be available under /compiler of any virtualhost defined in apache and compiler can now live together with the main site or other services. This might not work with apache 2.4.

We will most probably need to change our tests to try /compiler instead of /.

It is tested for integration with the website script (if the website install is run first) but not if compiler is pulled and run alone (that's the reason of the hold flag).
