### PR TITLE
Limit execution time for library tests

### DIFF
--- a/Symfony/src/Codebender/CompilerBundle/Controller/DefaultController.php
+++ b/Symfony/src/Codebender/CompilerBundle/Controller/DefaultController.php
@@ -54,6 +54,11 @@ class DefaultController extends Controller
         if ($version == "v1") {
             $requestObject = $this->getRequest();
             $request = $requestObject->getContent();
+            // Custom headers used during library tests.
+            // They don't affect the compiler's response and make our life easier.
+            if ($requestObject->headers->get('X-Set-Exec-Time') == 'true') {
+                ini_set('max_execution_time', '30');
+            }
             $mongoProjectId = $requestObject->headers->get('X-Mongo-Id');
 
             //Get the compiler service

--- a/Symfony/src/Codebender/CompilerBundle/Controller/DefaultController.php
+++ b/Symfony/src/Codebender/CompilerBundle/Controller/DefaultController.php
@@ -52,13 +52,18 @@ class DefaultController extends Controller
         }
 
         if ($version == "v1") {
-            $request = $this->getRequest()->getContent();
+            $requestObject = $this->getRequest();
+            $request = $requestObject->getContent();
+            $mongoProjectId = $requestObject->headers->get('X-Mongo-Id');
 
             //Get the compiler service
             /** @var CompilerHandler $compiler */
             $compiler = $this->get('compiler_handler');
 
             $reply = $compiler->main($request, $params);
+            if ($mongoProjectId != '') {
+                $reply['mongo-id'] = $mongoProjectId;
+            }
 
             return new Response(json_encode($reply));
         } else {

--- a/Symfony/src/Codebender/CompilerBundle/Controller/DefaultController.php
+++ b/Symfony/src/Codebender/CompilerBundle/Controller/DefaultController.php
@@ -19,79 +19,74 @@ use Codebender\CompilerBundle\Handler\DeletionHandler;
 
 class DefaultController extends Controller
 {
-	public function statusAction()
-	{
-		return new Response(json_encode(array("success" => true, "status" => "OK")));
-	}
+    public function statusAction()
+    {
+        return new Response(json_encode(array("success" => true, "status" => "OK")));
+    }
 
-	public function testAction($authorizationKey)
-	{
-		$params = $this->generateParameters();
+    public function testAction($authorizationKey)
+    {
+        $params = $this->generateParameters();
 
-		if ($authorizationKey !== $params["authorizationKey"])
-		{
-			return new Response(json_encode(array("success" => false, "step" => 0, "message" => "Invalid authorization key.")));
-		}
+        if ($authorizationKey !== $params["authorizationKey"]) {
+            return new Response(json_encode(array("success" => false, "step" => 0, "message" => "Invalid authorization key.")));
+        }
 
-		set_time_limit(0); // make the script execution time unlimited (otherwise the request may time out)
+        set_time_limit(0); // make the script execution time unlimited (otherwise the request may time out)
 
-		// change the current Symfony root dir
-		chdir($this->get('kernel')->getRootDir()."/../");
+        // change the current Symfony root dir
+        chdir($this->get('kernel')->getRootDir() . "/../");
 
-		//TODO: replace this with a less horrible way to handle phpunit
-		exec("phpunit -c app --stderr 2>&1", $output, $return_val);
+        //TODO: replace this with a less horrible way to handle phpunit
+        exec("phpunit -c app --stderr 2>&1", $output, $return_val);
 
-		return new Response(json_encode(array("success" => (bool) !$return_val, "message" => implode("\n", $output))));
-	}
+        return new Response(json_encode(array("success" => (bool)!$return_val, "message" => implode("\n", $output))));
+    }
 
-	public function indexAction($authorizationKey, $version)
-	{
-		$params = $this->generateParameters();
+    public function indexAction($authorizationKey, $version)
+    {
+        $params = $this->generateParameters();
 
-		if ($authorizationKey !== $params["authorizationKey"])
-		{
-			return new Response(json_encode(array("success" => false, "step" => 0, "message" => "Invalid authorization key.")));
-		}
+        if ($authorizationKey !== $params["authorizationKey"]) {
+            return new Response(json_encode(array("success" => false, "step" => 0, "message" => "Invalid authorization key.")));
+        }
 
-		if ($version == "v1")
-		{
-			$request = $this->getRequest()->getContent();
+        if ($version == "v1") {
+            $request = $this->getRequest()->getContent();
 
-			//Get the compiler service
-			/** @var CompilerHandler $compiler */
-			$compiler = $this->get('compiler_handler');
+            //Get the compiler service
+            /** @var CompilerHandler $compiler */
+            $compiler = $this->get('compiler_handler');
 
-			$reply = $compiler->main($request, $params);
+            $reply = $compiler->main($request, $params);
 
-			return new Response(json_encode($reply));
-		}
-		else
-		{
-			return new Response(json_encode(array("success" => false, "step" => 0, "message" => "Invalid API version.")));
-		}
-	}
+            return new Response(json_encode($reply));
+        } else {
+            return new Response(json_encode(array("success" => false, "step" => 0, "message" => "Invalid API version.")));
+        }
+    }
 
-	public function deleteAllObjectsAction($authorizationKey, $version)
-	{
-		if ($this->container->getParameter('authorizationKey') != $authorizationKey) {
+    public function deleteAllObjectsAction($authorizationKey, $version)
+    {
+        if ($this->container->getParameter('authorizationKey') != $authorizationKey) {
             return new Response(json_encode(
                 array('success' => false, 'step' => 0, 'message' => 'Invalid authorization key.')
             ));
         }
 
-		if ($version != 'v1') {
+        if ($version != 'v1') {
             return new Response(json_encode(
                 array('success' => false, 'step' => 0, 'message' => 'Invalid API version.')
             ));
         }
 
-		//Get the compiler service
-		/** @var DeletionHandler $deleter */
-		$deleter = $this->get('deletion_handler');
+        //Get the compiler service
+        /** @var DeletionHandler $deleter */
+        $deleter = $this->get('deletion_handler');
 
-		$response = $deleter->deleteAllObjects();
+        $response = $deleter->deleteAllObjects();
 
-		if ($response['success'] !== true) {
+        if ($response['success'] !== true) {
             return new Response(json_encode(
                 array('success' => false, 'step' => 0, 'message' => 'Failed to access object files directory.')
             ));
@@ -106,74 +101,72 @@ class DefaultController extends Controller
                 $response['deletionStats'],
                 array("Files not deleted" => $response['notDeletedFiles'])
             )));
-	}
+    }
 
-	public function deleteSpecificObjectsAction($authorizationKey, $version, $option, $cachedObjectToDelete)
-	{
-		if ($this->container->getParameter('authorizationKey') != $authorizationKey) {
+    public function deleteSpecificObjectsAction($authorizationKey, $version, $option, $cachedObjectToDelete)
+    {
+        if ($this->container->getParameter('authorizationKey') != $authorizationKey) {
             return new Response(json_encode(
                 array('success' => false, 'step' => 0, 'message' => 'Invalid authorization key.')
             ));
         }
 
-		if ($version != 'v1') {
+        if ($version != 'v1') {
             return new Response(json_encode(
                 array('success' => false, 'step' => 0, 'message' => 'Invalid API version.')
             ));
         }
 
-		//Get the compiler service
-		/** @var DeletionHandler $deleter */
-		$deleter = $this->get('deletion_handler');
+        //Get the compiler service
+        /** @var DeletionHandler $deleter */
+        $deleter = $this->get('deletion_handler');
 
-		$response = $deleter->deleteSpecificObjects($option, $cachedObjectToDelete);
+        $response = $deleter->deleteSpecificObjects($option, $cachedObjectToDelete);
 
-		if ($response['success'] !== true) {
-			return new Response(json_encode(
+        if ($response['success'] !== true) {
+            return new Response(json_encode(
                 array('success' => false, 'step' => 0, 'message' => 'Failed to access object files directory.')
             ));
-		}
+        }
 
-		if (!empty($response["notDeletedFiles"])) {
-			$message = 'Failed to delete one or more of the specified core object files.';
+        if (!empty($response["notDeletedFiles"])) {
+            $message = 'Failed to delete one or more of the specified core object files.';
             if ($option == 'library') {
                 $message = 'Failed to delete one or more of the specified library object files.';
             }
 
-			return new Response(json_encode(
+            return new Response(json_encode(
                 array_merge(array('success' => false, 'step' => 0, 'message' => $message), $response)
             ));
-		}
+        }
 
         $message = 'Core object files deleted successfully.';
-        if ($option == 'library'){
+        if ($option == 'library') {
             $message = 'Library deleted successfully.';
         }
 
-		return new Response(json_encode(array_merge(array('success' => true, 'message' => $message), $response)));
-	}
+        return new Response(json_encode(array_merge(array('success' => true, 'message' => $message), $response)));
+    }
 
-	/**
-	 * \brief Creates a list of the configuration parameters to be used in the compilation process.
-	 *
-	 * \return An array of the parameters.
-	 *
-	 * This function accesses the Symfony global configuration parameters, and creates an array that our handlers (which
-	 * don't have access to them) can use them.
-
-	 */
-	private function generateParameters()
-	{
+    /**
+     * \brief Creates a list of the configuration parameters to be used in the compilation process.
+     *
+     * \return An array of the parameters.
+     *
+     * This function accesses the Symfony global configuration parameters, and creates an array that our handlers (which
+     * don't have access to them) can use them.
+     */
+    private function generateParameters()
+    {
         $parameters = array("binutils", "python", "clang", "logdir", "temp_dir", "archive_dir", "autocompletion_dir", "autocompleter", "cflags", "cppflags", "asflags", "arflags", "ldflags", "ldflags_tail", "clang_flags", "objcopy_flags", "size_flags", "output", "arduino_cores_dir", "external_core_files", "authorizationKey");
 
-		$compiler_config = array();
+        $compiler_config = array();
 
-		foreach ($parameters as $parameter)
-		{
-			$compiler_config[$parameter] = $this->container->getParameter($parameter);
-		}
+        foreach ($parameters as $parameter) {
+            $compiler_config[$parameter] = $this->container->getParameter($parameter);
+        }
 
-		return $compiler_config;
-	}
+        return $compiler_config;
+    }
 
 }


### PR DESCRIPTION
### ChangeLog

Added a check for a custom header (`X-Set-Exec-Time`). When the HTTP header is detected, the compilation execution time is limited to 30 seconds. This way we can avoid tests crashing for very long compilation times.
