### PR TITLE
Removed extra base64 encoding step

### DIFF
--- a/Symfony/src/Codebender/CompilerBundle/Handler/CompilerV2Handler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/CompilerV2Handler.php
@@ -466,10 +466,6 @@ class CompilerV2Handler extends CompilerHandler
             ];
         }
 
-        // Don't return unprintable characters.  Base64 encode if necessary.
-        if ($this->isBinaryObject($content))
-            $content = base64_encode($content);
-
         // Get the size of the requested output file and return to the caller
         $size_cmd = $this->builderPref("recipe.size.pattern");
         $size_regex = $this->builderPref("recipe.size.regex");


### PR DESCRIPTION
### ChangeLog

The compilation output is always encoded to base64, whether it contains non-printable characters or not. The extra check had to be removed, as it would result in double base64-encoding of binary output contents.
