### PR TITLE
Put back HTTP header checks used in library tests

### DIFF
--- a/Symfony/src/Codebender/CompilerBundle/Controller/DefaultController.php
+++ b/Symfony/src/Codebender/CompilerBundle/Controller/DefaultController.php
@@ -63,13 +63,24 @@ class DefaultController extends Controller
             ]);
         }
 
-        $request = $this->getRequest()->getContent();
+        $requestObject = $this->getRequest();
+        $request = $requestObject->getContent();
         if ($version == 'v1') {
+            // Custom headers used during library tests.
+            // They don't affect the compiler's response and make our life easier.
+            if ($requestObject->headers->get('X-Set-Exec-Time') == 'true') {
+                ini_set('max_execution_time', '30');
+            }
+            $mongoProjectId = $requestObject->headers->get('X-Mongo-Id');
+
             //Get the compiler service
             /** @var CompilerHandler $compiler */
             $compiler = $this->get('compiler_handler');
 
             $reply = $compiler->main($request, $params);
+            if ($mongoProjectId != '') {
+                $reply['mongo-id'] = $mongoProjectId;
+            }
 
             return new JsonResponse($reply);
         }


### PR DESCRIPTION
### Changelog

These were removed by mistake when we merged the 1.6.7 compiler changes. They need to be put back in order for the library tests to work
