### PR TITLE
Hpp support

### DIFF
--- a/Symfony/src/Codebender/CompilerBundle/Handler/CompilerHandler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/CompilerHandler.php
@@ -1134,7 +1134,7 @@ class CompilerHandler
 
 		$ext = pathinfo($file, PATHINFO_EXTENSION);
 		if (!in_array($ext, array("ino", "c", "cpp", "h", "hpp")))
-			return array("success" => false, "message" => "Sorry, autocompletion is only supported for .ino, .c, .cpp or .h files.");
+			return array("success" => false, "message" => "Sorry, autocompletion is only supported for .ino, .c, .cpp, .h or .hpp files.");
 		if ($ext == "ino")
 		{
 			$ext = "cpp";
@@ -1149,7 +1149,7 @@ class CompilerHandler
 			$json_array = array("file" => $compiler_config["autocmpfile"], "row" => $compiler_config["autocmprow"], "column" => $compiler_config["autocmpcol"], "prefix" => $compiler_config["autocmpprefix"], "command" => $commandline);
 
 		}
-		elseif ($ext == "cpp" || $ext == "h")
+		elseif ($ext == "cpp" || $ext == "h" || $ext == "hpp" )
 		{
 			$commandline = "$CPP $CPPFLAGS $core_includes $target_arch -MMD $include_directories -c -o $filename.o $filename.$ext 2>&1";
 			$json_array = array("file" => $compiler_config["autocmpfile"], "row" => $compiler_config["autocmprow"], "column" => $compiler_config["autocmpcol"], "prefix" => $compiler_config["autocmpprefix"], "command" => $commandline);

--- a/Symfony/src/Codebender/CompilerBundle/Handler/UtilityHandler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/UtilityHandler.php
@@ -36,7 +36,7 @@ class UtilityHandler
 		// separated by "|" to be used in regular expressions. They are also
 		// used as keys in an array that will contain the paths of all the
 		// extracted files.
-		$allowedExtensions = array("c", "cpp", "h", "inc", "ino", "o", "S");
+		$allowedExtensions = array("c", "cpp", "h", "inc", "ino", "o", "S", "hpp");
 		$files = array();
 		foreach ($allowedExtensions as $ext)
 			$files[$ext] = array();

--- a/Symfony/src/Codebender/CompilerBundle/Tests/Controller/DefaultControllerFunctionalTest.php
+++ b/Symfony/src/Codebender/CompilerBundle/Tests/Controller/DefaultControllerFunctionalTest.php
@@ -50,6 +50,30 @@ class DefaultControllerFunctionalTest extends WebTestCase
 
     }
 
+    public function testSkchHppUnoSyntaxCheck()
+    {
+        $files = array(array("filename" => "SkchHpp.ino", "content" => "#include<jsonhp.hpp>\nvoid setup()\n{\nSerial.begin(9600);\n\tint x = vardeb+5;\nSerial.println(x);\n}\n\nvoid loop()\n{\n\n}\n"));
+        $format = "syntax";
+        $version = "105";
+        $libraries = array('jsonlib' => array('files' => array('filename' => 'jsonhp.hpp', 'content' => "#define vardeb 3;\n")));
+        $build = array("mcu" => "atmega328p", "f_cpu" => "16000000", "core" => "arduino", "variant" => "standard");
+
+        $data = json_encode(array("files" => $files, "format" => $format, "version" => $version, "libraries" => $libraries, "build" => $build));
+
+        $client = static::createClient();
+
+        $authorizationKey = $client->getContainer()->getParameter("authorizationKey");
+
+        $client->request('POST', '/' . $authorizationKey . '/v1', array(), array(), array(), $data);
+
+        $response = json_decode($client->getResponse()->getContent(), true);
+
+        $this->assertEquals($response["success"], true);
+        $this->assertTrue(is_numeric($response["time"]));
+
+    }
+
+
     public function testBlinkUnoSyntaxCheck()
     {
         $files = array(array("filename" => "Blink.ino", "content" => "int led = 13;\nvoid setup() {pinMode(led, OUTPUT);}\nvoid loop() {\ndigitalWrite(led, HIGH);\ndelay(1000);\ndigitalWrite(led, LOW);\ndelay(1000);\n}\n"));


### PR DESCRIPTION
> Enable compiler to extract and handle .hpp files included in arduino projects.
> New test added and executed successfully.
> Added 'hpp' in Autocompletion supported files.
