### PR TITLE
Escaping HTML special characters in v2 compiler output.

### DIFF
--- a/Symfony/src/Codebender/CompilerBundle/Handler/CompilerV2Handler.php
+++ b/Symfony/src/Codebender/CompilerBundle/Handler/CompilerV2Handler.php
@@ -780,6 +780,9 @@ class CompilerV2Handler extends CompilerHandler
             $message .= $modified . "\n";
         }
 
+        // Escape HTML special characters
+        $message = htmlspecialchars($message);
+
         return $message;
     }
 }


### PR DESCRIPTION
### Changes
- Escaping HTML special characters in `v2` compiler output
